### PR TITLE
Build project for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ### STAGE 1: Build ###
 FROM node:14.17-alpine AS build
+ARG BUILD_TYPE=build-release
 WORKDIR /app
 
 COPY package.json ./
@@ -9,7 +10,7 @@ COPY e2e e2e
 COPY src src
 COPY angular.json .browserslistrc karma.conf.js tsconfig.app.json tsconfig.json tsconfig.spec.json tslint.json ./
 
-RUN npm run build
+RUN npm run $BUILD_TYPE
 
 ### STAGE 2: Run ###
 FROM nginx:1.17.1-alpine

--- a/angular.json
+++ b/angular.json
@@ -59,8 +59,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "3mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build-release": "ng build --configuration=production",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Building the project for production allows minifying JS and increases overall performance of the website.